### PR TITLE
Add `build = false` to Cargo.toml to fix nightly breakage

### DIFF
--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -9,6 +9,7 @@ description = """
 Internal dependency for roboime-next.
 """
 # the build script is not being used right now
+build = false
 #build = "build.rs"
 
 [dependencies]


### PR DESCRIPTION
In rust-lang/rust#40197 it was discovered that this crate no longer builds on
nightly due to a rust-lang/cargo#3664 where Cargo will now infer that `build.rs`
is a build script unless explicitly configured with `build = false`.

Currently we're not intending to revert the Cargo change, but let me know if
this causes trouble though and we can certainly reconsider!